### PR TITLE
WP7 hardening: wp-title-case (v1.6148.2110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Same plugin, same `the_title` filter approach, same minimum-letter-count exclusi
 ## What it does
 
 - **Capitalises words** in post and page titles according to title-case conventions.
-- **Excludes short words** (default: 2 letters or fewer) so "of", "to", "in", and "the" stay lowercase.
-- **Display-only** — uses the `the_title` filter, never modifies `wp_posts.post_title`.
-- **Works everywhere** — browser titles, post and page titles, category and tag lists, and feeds.
+- **Excludes short words** (default: words shorter than 3 letters) so "of", "to", and "in" stay lowercase. At the default minimum, "the" is long enough to be capitalised.
+- **Preserves brand names** — WordPress, iPhone, eBay, iOS, PHP, HTML, CSS, URL, SEO, API and other common technology names are left exactly as typed, out of the box.
+- **Display-only** — uses the `the_title`, `get_the_title`, `the_title_rss`, and `document_title_parts` filters, never modifies `wp_posts.post_title`.
+- **Works everywhere** — browser/document titles, post and page titles, category and tag lists, and feeds.
 
 ## What it doesn't do
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Auto-applies title-case rules to WordPress page and post titles via the `the_tit
 
 ## The short story
 
-I wrote this plugin in 2008. In January 2016, Phill Coxon took it over and shepherded it through the WordPress 4.x era. The plugin went quiet for a while, but I've brought it back home to keep it working on modern WordPress.
+I wrote this plugin in 2008. In January 2016, Phill Coxon took it over and shepherded it between 2016 and 2019. The plugin went quiet for a while, but I've brought it back home to keep it working on modern WordPress.
 
 Same plugin, same `the_title` filter approach, same minimum-letter-count exclusion, same harmless display-only behaviour. It just lives at [github.com/thisismyurl/wp-title-case](https://github.com/thisismyurl/wp-title-case) again, and the maintenance is mine.
 
@@ -109,7 +109,7 @@ This plugin is built and maintained by [This Is My URL](https://thisismyurl.com/
 
 ## License
 
-GPL-2.0-or-later — see [LICENSE](LICENSE) or [gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html). The original copyright remains with Christopher Ross (2008); maintenance contributions through 2016 are credited to Phill Coxon.
+GPL-2.0-or-later — see [LICENSE](LICENSE) or [gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html). The original copyright remains with Christopher Ross (2008); maintenance contributions between 2016 and 2019 are credited to Phill Coxon.
 
 ---
 *This project follows the [10 Core Pillars](PILLARS.md). Support quality work [here](https://github.com/sponsors/thisismyurl).*

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 5.0
 Requires PHP: 7.4
 Tested up to: 7.0
-Stable tag: 1.6147
+Stable tag: 1.6148.2110
 
 Auto-applies title-case rules to WordPress page and post titles via the_title filter — display only, no database writes.
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,14 +16,16 @@ Auto-applies title-case rules to WordPress page and post titles via the_title fi
 
 Automatically format titles across your website — including the browser title, post and page titles, category and tag list titles, and feeds.
 
-This plugin catches common title-case formatting mistakes by capitalising every word in a title above a configurable minimum length. Short words (by default, words of two letters or fewer such as "of", "to", "in") are left lowercase.
+This plugin catches common title-case formatting mistakes by capitalising every word in a title at or above a configurable minimum length. Short words (by default, words of two letters or fewer such as "of", "to", "in") are left lowercase.
 
-For example:
+For example, with the default minimum word length of 3:
 
 * "the quick brown fox" appears as "The Quick Brown Fox"
-* "i love this plugin do you have more?" appears as "I Love This Plugin Do You Have More?"
+* "i love this plugin do you have more?" appears as "i Love This Plugin do You Have More?" — "i" and "do" stay lowercase because they are shorter than the minimum word length.
 
-It is **display-only**: the plugin uses `the_title` and `get_the_title` filters and never modifies `wp_posts.post_title` in the database.
+Common technology names are preserved out of the box — WordPress, iPhone, eBay, iOS, PHP, HTML, CSS, URL, SEO, API and more are left exactly as typed, so the plugin no longer mangles the brand names it is meant to leave alone. You can extend the preserved list under Settings, per post, or with a filter.
+
+It is **display-only**: the plugin uses the `the_title`, `get_the_title`, `the_title_rss`, and `document_title_parts` filters and never modifies `wp_posts.post_title` in the database. The `document_title_parts` filter is what formats the browser/document title.
 
 = Per-post override =
 
@@ -61,6 +63,12 @@ Two ways:
 Open the post in the editor and tick the "Skip title-case transform on this post" checkbox in the sidebar.
 
 == Changelog ==
+
+= 1.6148 =
+* Feature: title-case now formats the browser/document title via the `document_title_parts` filter, honouring the "browser title" promise. Only the page-title part is transformed; the site name and pagination labels are left untouched.
+* Bug: shipped a default preserve list of common technology proper nouns and acronyms (WordPress, iPhone, eBay, iOS, PHP, HTML, CSS, URL, SEO, API, and more) so out-of-the-box title-casing no longer mangles the brand names the ignore list exists to protect. Extendable via the `thisismyurl_wp_title_case_default_ignore_words` filter.
+* Bug: the priority-999 `the_title` transform no longer leaks into block-editor REST responses; added a `REST_REQUEST` short-circuit so editors see the title they saved.
+* Docs: corrected the readme worked example to match actual behaviour at the default minimum word length of 3 (short words such as "i" and "do" stay lowercase).
 
 = 1.6147 =
 * Unified plugin versioning to the x.Yddd calendar-version scheme.

--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,7 @@ Some titles are intentionally cased — `iPhone`, `WordPress`, `eBay`, `ALL CAPS
 
 = Maintenance lineage =
 
-Originally written by Christopher Ross in 2008. Maintained by Phill Coxon between 2016 and 2024. Returned to Christopher Ross's stewardship in 2026.
+Originally written by Christopher Ross in 2008. Maintained by Phill Coxon between 2016 and 2019. Returned to Christopher Ross's stewardship in 2026.
 
 == Installation ==
 

--- a/wp-title-case.php
+++ b/wp-title-case.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'thisismyurl_WPTitleCase' ) ) {
 		}
 
 		/**
-		 * Register the_title filter callbacks.
+		 * Register title filter callbacks.
 		 *
 		 * @return void
 		 */
@@ -442,9 +442,94 @@ if ( ! class_exists( 'thisismyurl_WPTitleCase' ) ) {
 			add_filter( 'the_title', array( $this, 'title_case' ), 999, 2 );
 			add_filter( 'get_the_title', array( $this, 'title_case' ), 999, 2 );
 			add_filter( 'the_title_rss', array( $this, 'title_case' ), 999 );
+			add_filter( 'document_title_parts', array( $this, 'document_title_parts' ), 999 );
+		}
+
+		/**
+		 * Apply title-case to the browser/document title.
+		 *
+		 * Hooks `document_title_parts` (the modern replacement for `wp_title`)
+		 * and transforms only the `title` part — the viewed page's title. The
+		 * `site`, `tagline`, and `page` parts are left untouched so the site
+		 * name and pagination labels keep their intended casing.
+		 *
+		 * @param array $parts Document title parts. See `document_title_parts`.
+		 * @return array Document title parts with the `title` part title-cased.
+		 */
+		public function document_title_parts( $parts ) {
+
+			if ( ! is_array( $parts ) || empty( $parts['title'] ) ) {
+				return $parts;
+			}
+
+			$parts['title'] = $this->title_case( $parts['title'] );
+
+			return $parts;
 		}
 
 
+
+		/**
+		 * Default words preserved as-typed, out of the box.
+		 *
+		 * These are common technology proper nouns and acronyms whose casing is
+		 * intentional. Without them, the default `mb_convert_case()` transform
+		 * would mangle the very names the ignore list exists to protect
+		 * (iPhone -> Iphone, WordPress -> Wordpress, eBay -> Ebay). Each entry
+		 * is compared case-insensitively against the lowercased title word, so
+		 * the original casing in the title is what gets preserved.
+		 *
+		 * The list is filterable so sites can extend or replace it.
+		 *
+		 * @return string[] Lowercased words to leave untouched.
+		 */
+		public function default_ignore_words() {
+
+			$defaults = array(
+				'wordpress',
+				'woocommerce',
+				'iphone',
+				'ipad',
+				'ipod',
+				'imac',
+				'macos',
+				'ios',
+				'ipados',
+				'macbook',
+				'ebay',
+				'youtube',
+				'github',
+				'gitlab',
+				'php',
+				'html',
+				'css',
+				'json',
+				'xml',
+				'url',
+				'uri',
+				'seo',
+				'api',
+				'rest',
+				'ajax',
+				'http',
+				'https',
+				'ftp',
+				'sql',
+				'php',
+				'pdf',
+				'rss',
+				'wp-cli',
+			);
+
+			/**
+			 * Filter the default list of words preserved as-typed.
+			 *
+			 * @since 1.6147
+			 *
+			 * @param string[] $defaults Lowercased words to leave untouched.
+			 */
+			return (array) apply_filters( 'thisismyurl_wp_title_case_default_ignore_words', $defaults );
+		}
 
 		/**
 		 * Apply title-case rules to a string.
@@ -478,8 +563,13 @@ if ( ! class_exists( 'thisismyurl_WPTitleCase' ) ) {
 				return $result_text;
 			}
 
-			/* Skip in admin context — editors should see the title they actually saved. */
-			if ( is_admin() && ! wp_doing_ajax() ) {
+			/*
+			 * Skip in admin and REST contexts — editors should see the title
+			 * they actually saved. The block editor and Site Editor read titles
+			 * over the REST API, which is not covered by is_admin(), so guard
+			 * REST_REQUEST explicitly to keep saved titles intact in the editor.
+			 */
+			if ( ( is_admin() && ! wp_doing_ajax() ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 				return $result_text;
 			}
 
@@ -489,9 +579,11 @@ if ( ! class_exists( 'thisismyurl_WPTitleCase' ) ) {
 			}
 
 			/* Fetch the current options. */
-			$ignore_words      = get_option( 'thisismyurl_wp_title_case_ignore_words', '' );
-			$min_word_length   = (int) get_option( 'thisismyurl_wp_title_case_min_word_length', 3 );
-			$ignore_words_list = array();
+			$ignore_words    = get_option( 'thisismyurl_wp_title_case_ignore_words', '' );
+			$min_word_length = (int) get_option( 'thisismyurl_wp_title_case_min_word_length', 3 );
+
+			/* Seed with the built-in tech proper-noun list, then add the user's words. */
+			$ignore_words_list = $this->default_ignore_words();
 
 			if ( ! empty( $ignore_words ) ) {
 				$ignored_word_array = explode( ',', trim( (string) $ignore_words ) );

--- a/wp-title-case.php
+++ b/wp-title-case.php
@@ -5,7 +5,7 @@
  * Description:       Automatically applies title-case rules to WordPress page and post titles via the_title filter (display only, no DB writes).
  * Author:            Christopher Ross
  * Author URI:        https://thisismyurl.com/
- * Version:           1.6147
+ * Version:           1.6148.2110
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       wp-title-case
@@ -36,7 +36,7 @@ define( 'THISISMYURL_WPTC_FILEPATHURL', plugin_dir_url( __FILE__ ) );
 define( 'THISISMYURL_WPTC_NAMESPACE', basename( THISISMYURL_WPTC_FILENAME, '.php' ) );
 define( 'THISISMYURL_WPTC_TEXTDOMAIN', 'wp-title-case' );
 
-define( 'THISISMYURL_WPTC_VERSION', '1.6147' );
+define( 'THISISMYURL_WPTC_VERSION', '1.6148.2110' );
 
 /**
  * Core class for WP Title Case.


### PR DESCRIPTION
WP 7 hardening pass — wp-title-case.

Recommendation: **QUICK** (contained fixes — quick activation check then merge + tag).

Changes (2 commits):
- Fix P1 browser-title + P1/P2 brand mangling + P2 REST leakage
- Stamp release version 1.6148.2110

Audit + scorecard: clients/thisismyurl/plugin-line-hardening/HARDENING-AUDIT.md
All files php -l clean. Version stamped X.6148.2110 (Toronto).