### PR TITLE
Remove duplicate 'php' in ignore_words array

### DIFF
--- a/wp-title-case.php
+++ b/wp-title-case.php
@@ -515,7 +515,6 @@ if ( ! class_exists( 'thisismyurl_WPTitleCase' ) ) {
 				'https',
 				'ftp',
 				'sql',
-				'php',
 				'pdf',
 				'rss',
 				'wp-cli',


### PR DESCRIPTION
## Summary

Plugin Check flag: array had 'php' twice (indices 503 and 518).

## Changes

Plugin Check (PHPCS) fixes — no behaviour changes to production functionality.

## Test plan

- [ ] Install on a WordPress test site and confirm plugin activates without errors
- [ ] Verify Plugin Check passes with no new warnings on the modified files
- [ ] Confirm existing functionality unchanged

_AI-assisted: fixes researched and applied with Claude Sonnet 4.6; reviewed by Christopher Ross._